### PR TITLE
fix Cannot read property 0 of undefined during index update

### DIFF
--- a/lib/explorer.js
+++ b/lib/explorer.js
@@ -284,7 +284,7 @@ module.exports = {
     module.exports.syncLoop(vout.length, function (loop) {
       var i = loop.iteration();
       // make sure vout has an address
-      if (vout[i].scriptPubKey.type != 'nonstandard' && vout[i].scriptPubKey.type != 'nulldata') { 
+      if (vout[i].scriptPubKey.type != 'nonstandard' && vout[i].scriptPubKey.type != 'nulldata' && vout[i].scriptPubKey.hasOwnProperty("addresses")) { 
         // check if vout address is unique, if so add it array, if not add its amount to existing index
         //console.log('vout:' + i + ':' + txid);
         module.exports.is_unique(arr_vout, vout[i].scriptPubKey.addresses[0], function(unique, index) {


### PR DESCRIPTION
fix error 
TypeError: Cannot read property '0' of undefined
    at module.exports.syncLoop.arr_vout.(anonymous function).amount